### PR TITLE
cleanup ansible 2.4 change for 2.8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,4 +25,3 @@
 
 # Configure Apache vhosts.
 - include_tasks: "configure-{{ ansible_os_family }}.yml"
-  static: no


### PR DESCRIPTION
this little leftover from changing "include" to "include_task" will cause:

ERROR! 'static' is not a valid attribute for a TaskInclude